### PR TITLE
Fix compression

### DIFF
--- a/src/Otor.MsixHero.Cli/Executors/Edit/BaseEditVerbExecutor.cs
+++ b/src/Otor.MsixHero.Cli/Executors/Edit/BaseEditVerbExecutor.cs
@@ -87,7 +87,7 @@ namespace Otor.MsixHero.Cli.Executors.Edit
                             {
                                 await this.Console.WriteInfo(string.Format(Resources.Localization.CLI_Executor_SavingFile_Format, Path.GetFileName(this._package))).ConfigureAwait(false);
                                 // 3) Pack again
-                                await msixMgr.Pack(MakeAppxPackOptions.CreateFromDirectory(tempFolder, this._package, false)).ConfigureAwait(false);
+                                await msixMgr.Pack(MakeAppxPackOptions.CreateFromDirectory(tempFolder, this._package)).ConfigureAwait(false);
                                 await this.OnFinished().ConfigureAwait(false);
                             }
 

--- a/src/Otor.MsixHero.Infrastructure/ThirdParty/Sdk/MakeAppxPackOptions.cs
+++ b/src/Otor.MsixHero.Infrastructure/ThirdParty/Sdk/MakeAppxPackOptions.cs
@@ -121,6 +121,6 @@ public class MakeAppxPackOptions : MakeAppxOptions
             throw new ArgumentNullException(nameof(targetPackagePath));
         }
 
-        return CreateFromDirectory(new DirectoryInfo(sourceDirectory), new FileInfo(targetPackagePath), validate, compress);
+        return CreateFromDirectory(new DirectoryInfo(sourceDirectory), new FileInfo(targetPackagePath), compress, validate);
     }
 }


### PR DESCRIPTION
I removed the compression-parameter at BaseEditVerbExcecutor.cs:90. Not sure if that is the best solution or if it should be dependent on something else?

Also the order of the arguments at MakeAppxPackOptions.cs:124 was wrong.

Fix for issue: https://github.com/marcinotorowski/MSIX-Hero/issues/136