### PR TITLE
allow timestamp none

### DIFF
--- a/src/Otor.MsixHero.Cli/Executors/Standard/SignVerbExecutor.cs
+++ b/src/Otor.MsixHero.Cli/Executors/Standard/SignVerbExecutor.cs
@@ -246,7 +246,10 @@ namespace Otor.MsixHero.Cli.Executors.Standard
 
             if (this.Verb.TimeStampUrl != null && !Uri.TryCreate(this.Verb.TimeStampUrl, UriKind.Absolute, out _))
             {
-                return await this.GetSetValueError(nameof(SignVerb.TimeStampUrl), string.Format(Resources.Localization.CLI_Executor_Sign_Error_InvalidTimestampUrl_Format, this.Verb.TimeStampUrl));
+                if (this.Verb.TimeStampUrl.ToLower() == "none")
+                    this.Verb.TimeStampUrl = null;
+                else
+                    return await this.GetSetValueError(nameof(SignVerb.TimeStampUrl), string.Format(Resources.Localization.CLI_Executor_Sign_Error_InvalidTimestampUrl_Format, this.Verb.TimeStampUrl));
             }
 
             return StandardExitCodes.ErrorSuccess;

--- a/src/Otor.MsixHero.Cli/Executors/Standard/SignVerbExecutor.cs
+++ b/src/Otor.MsixHero.Cli/Executors/Standard/SignVerbExecutor.cs
@@ -247,7 +247,7 @@ namespace Otor.MsixHero.Cli.Executors.Standard
             if (this.Verb.TimeStampUrl != null && !Uri.TryCreate(this.Verb.TimeStampUrl, UriKind.Absolute, out _))
             {
                 if (this.Verb.TimeStampUrl.ToLower() == "none")
-                    this.Verb.TimeStampUrl = null;
+                    this.Verb.TimeStampUrl = "";
                 else
                     return await this.GetSetValueError(nameof(SignVerb.TimeStampUrl), string.Format(Resources.Localization.CLI_Executor_Sign_Error_InvalidTimestampUrl_Format, this.Verb.TimeStampUrl));
             }


### PR DESCRIPTION
This allows to avoid usage of timestamp servers when giving "-t none" as arg.

example usage:
`msixherocli.exe sign -t none --file some.pfx --password somepass "some.msix"`

should also solve this:
https://github.com/marcinotorowski/MSIX-Hero/discussions/151