### PR TITLE
fix: use UnicodeText format for clipboard to support Cyrillic (#160)

### DIFF
--- a/src/Otor.MsixHero.App/Modules/Containers/Commands/ContainersCommandHandler.cs
+++ b/src/Otor.MsixHero.App/Modules/Containers/Commands/ContainersCommandHandler.cs
@@ -159,7 +159,7 @@ namespace Otor.MsixHero.App.Modules.Containers.Commands
             var container = this._application.ApplicationState.Containers.SelectedContainer;
             if (container != null)
             {
-                Clipboard.SetText(GetCopyText(container), TextDataFormat.Text);
+                Clipboard.SetText(GetCopyText(container), TextDataFormat.UnicodeText);
             }
         }
 

--- a/src/Otor.MsixHero.App/Modules/Dialogs/PackageExpert/ViewModels/PackageExpertCommandHandler.cs
+++ b/src/Otor.MsixHero.App/Modules/Dialogs/PackageExpert/ViewModels/PackageExpertCommandHandler.cs
@@ -879,11 +879,11 @@ namespace Otor.MsixHero.App.Modules.Dialogs.PackageExpert.ViewModels
                         break;
                 }
 
-                Clipboard.SetText(toCopy.ToString().TrimEnd(), TextDataFormat.Text);
+                Clipboard.SetText(toCopy.ToString().TrimEnd(), TextDataFormat.UnicodeText);
             }
             else if (parameter is string stringParameter)
             {
-                Clipboard.SetText(stringParameter, TextDataFormat.Text);
+                Clipboard.SetText(stringParameter, TextDataFormat.UnicodeText);
             }
         }
 

--- a/src/Otor.MsixHero.App/Modules/EventViewer/Commands/EventViewerCommandHandler.cs
+++ b/src/Otor.MsixHero.App/Modules/EventViewer/Commands/EventViewerCommandHandler.cs
@@ -70,7 +70,7 @@ namespace Otor.MsixHero.App.Modules.EventViewer.Commands
             var log = this._application.ApplicationState.EventViewer.SelectedAppxEvent;
             if (log != null)
             {
-                Clipboard.SetText(GetCopyText(log), TextDataFormat.Text);
+                Clipboard.SetText(GetCopyText(log), TextDataFormat.UnicodeText);
             }
         }
 

--- a/src/Otor.MsixHero.App/Modules/PackageManagement/Commands/PackagesManagementCommandHandler.cs
+++ b/src/Otor.MsixHero.App/Modules/PackageManagement/Commands/PackagesManagementCommandHandler.cs
@@ -999,11 +999,11 @@ namespace Otor.MsixHero.App.Modules.PackageManagement.Commands
                     }
                 }
 
-                Clipboard.SetText(toCopy.ToString().TrimEnd(), TextDataFormat.Text);
+                Clipboard.SetText(toCopy.ToString().TrimEnd(), TextDataFormat.UnicodeText);
             }
             else if (parameter is string stringParameter)
             {
-                Clipboard.SetText(stringParameter, TextDataFormat.Text);
+                Clipboard.SetText(stringParameter, TextDataFormat.UnicodeText);
             }
         }
 


### PR DESCRIPTION
How to test:

1. create empty broken appx-file with Cyrillic letters in name
2. try to install the file
3. open "Events"
4. open last error
5. click "Copy to clipboard"
6. paste in notepad

```
New-Item -Path тест.appx -ItemType File
Add-AppxPackage -Path тест.appx
```

Before fix:

```
DateTime:	06.05.2026 16:22:34
Level:	Error
Source:	Microsoft-Windows-AppXDeploymentServer/Operational
ActivityId:	cb34b3d9-dc8e-0000-90c8-87cb8edcdc01
FilePath:	С‚РµСЃС‚.appx
PackageName:	С‚РµСЃС‚.appx
ErrorCode:	0x80073CF0
Opcode:	Info
ThreadId:	9564
User:	oleksii
Message:	AppX Deployment operation failed for package  with error 0x80073CF0. The specific error text for this failure is: error 0x8007000D: Opening the package from location С‚РµСЃС‚.appx failed.
Troubleshooting info: ERROR_INSTALL_OPEN_PACKAGE_FAILED | ERROR_INSTALL_OPEN_PACKAGE_FAILED
```

After fix:

```
DateTime:	06.05.2026 16:22:34
Level:	Error
Source:	Microsoft-Windows-AppXDeploymentServer/Operational
ActivityId:	cb34b3d9-dc8e-0000-90c8-87cb8edcdc01
FilePath:	тест.appx
PackageName:	тест.appx
ErrorCode:	0x80073CF0
Opcode:	Info
ThreadId:	9564
User:	oleksii
Message:	AppX Deployment operation failed for package  with error 0x80073CF0. The specific error text for this failure is: error 0x8007000D: Opening the package from location тест.appx failed.
Troubleshooting info: ERROR_INSTALL_OPEN_PACKAGE_FAILED | ERROR_INSTALL_OPEN_PACKAGE_FAILED
```